### PR TITLE
feat: add project 4-series build template

### DIFF
--- a/.github/workflows/projects-4series-builds.yml
+++ b/.github/workflows/projects-4series-builds.yml
@@ -1,0 +1,85 @@
+name: Build 4-Series
+
+on:
+  workflow_call:
+    inputs:
+      newVersion:
+        description: 'New version to release'
+        required: true
+        type: string
+      version:
+        description: 'The version of the file to build and push'
+        required: true
+        type: string
+      tag:
+        description: 'The tag of the image to build and push'
+        required: true
+        type: string
+      channel:
+        description: 'The channel of the image to build and push'
+        required: true
+        type: string
+
+env:
+  BUILD_TYPE: ${{ inputs.channel == '' && 'Release' || 'Debug' }}
+
+jobs:
+  Build_Project_4-Series:
+    runs-on: windows-latest
+    steps:
+      # Checkout the source repo
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        
+      # Get SLN Info
+      - name: Get SLN Info
+        id: get_sln_info
+        shell: powershell
+        run: |
+          $solution_file = Get-ChildItem .\*.4Series.sln -recurse
+          Write-Output $solution_file
+          echo "SOLUTION_FILE=$($solution_file.BaseName)"| Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+          $solution_path = Get-ChildItem *.4Series.sln -recurse 
+          $solution_path = $solution_path.FullName
+          $solution_path = $solution_path -replace "(?:[^\\]*\\){4}", ""
+          Write-Output $solution_path
+          echo "SOLUTION_PATH=$($solution_path)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      # Setup MS Build
+      - name: Setup MS Build
+        uses: microsoft/setup-msbuild@v1.1
+
+      # Restore Nuget Packages
+      - name: Restore Nuget Packages
+        run: nuget restore .\${{ steps.get_sln_info.outputs.SOLUTION_FILE }}.sln
+
+      # Build Solution        
+      - name: Build Solution
+        run: msbuild .\${{ steps.get_sln_info.outputs.SOLUTION_FILE }}.sln /p:Platform="Any CPU" /p:Configuration="${{ env.BUILD_TYPE }}" /p:Version="${{ inputs.version }}" /p:IncludeSourceRevisionInInformationalVersion=false -m
+
+      # Upload compiled .cpz files
+      - name: Upload Compiled .cpz Files
+        uses: actions/upload-artifact@v2
+        with:
+          name: compiled-cpz-files
+          path: '**/*.cpz'
+
+      # Get release notes
+      - name: Get Release Notes
+        uses: actions/download-artifact@v4
+        with:
+          name: change-log
+
+      # Upload Release
+      - name: Create Release
+        if: ${{ inputs.newVersion == 'true' }}
+        id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: '**/*.*(cpz|cplz)'
+          prerelease: ${{ inputs.channel != '' }}
+          tag: ${{ inputs.tag }}
+          commit: ${{ github.sha }}
+          bodyFile: ./CHANGELOG.md


### PR DESCRIPTION
Add 4-series build action that can be used for projects not associated with Essentials, plugins, or other workflows. 

- Removed nuget publishing
- Add publish/upload of final *.cpz