### PR TITLE
ci: add conventional-changelog-conventionalcommits package

### DIFF
--- a/.github/workflows/essentialsplugins-getversion.yml
+++ b/.github/workflows/essentialsplugins-getversion.yml
@@ -54,7 +54,7 @@ jobs:
         include: '.releaserc.json'
     - name: Get version number
       id: get_version
-      run: npx --package=semantic-release --package=@semantic-release/commit-analyzer --package=@semantic-release/release-notes-generator --package=@semantic-release/changelog --package=@semantic-release/exec -- semantic-release
+      run: npx --package=semantic-release --package=@semantic-release/commit-analyzer --package=@semantic-release/release-notes-generator --package=@semantic-release/changelog --package=@semantic-release/exec --package=conventional-changelog-conventionalcommits -- semantic-release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}
     - name: Print summary if no new version


### PR DESCRIPTION
This pull request makes a small update to the workflow configuration in `.github/workflows/essentialsplugins-getversion.yml`. The change adds the `conventional-changelog-conventionalcommits` package to the list of dependencies used when running the semantic release process.

* Added `conventional-changelog-conventionalcommits` to the `npx` command in the "Get version number" job to ensure proper changelog generation and commit analysis.