### PR TITLE
Reorder steps

### DIFF
--- a/.github/workflows/essentialsplugins-4Series-builds.yml
+++ b/.github/workflows/essentialsplugins-4Series-builds.yml
@@ -89,7 +89,7 @@ jobs:
         id: build
         shell: powershell
         run: |
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Build Solution`n"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Build Solution`n"
           
           $buildOutput = msbuild .\${{ steps.get_sln_info.outputs.SOLUTION_FILE }}.sln /p:Platform="Any CPU" /p:Configuration="$($ENV:BUILD_TYPE)" /p:Version="${{ inputs.version }}" /p:IncludeSourceRevisionInInformationalVersion=false -m 2>&1
           
@@ -105,9 +105,11 @@ jobs:
             Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- **Configuration**: $($ENV:BUILD_TYPE)`n"
             Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- **Version**: ${{ inputs.version }}`n"
             Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- **Solution**: ${{ steps.get_sln_info.outputs.SOLUTION_FILE }}.sln`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- **Build Log**: [Download build-output-log.zip](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`n"
           } else {
             Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "**BUILD FAILED** - Exit code: $LASTEXITCODE`n"
             Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "Check the step logs above for detailed error information.`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- **Build Log**: [Download build-output-log.zip](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`n"
             exit $LASTEXITCODE
           }   
 
@@ -116,7 +118,7 @@ jobs:
         if: failure() && steps.build.conclusion == 'failure'
         shell: powershell
         run: |
-          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Build Failed`n"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Build Failed Clean up`n"
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "The build output above shows the specific errors that caused the build to fail.`n`n"
           
           # Check if tag exists on remote and delete it
@@ -170,7 +172,8 @@ jobs:
           if ($null -eq $packageFile) {
             $msg = "No NuGet package found in the output directory. Please check if the build generated the package correctly."
             Write-Error $msg
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Check Package Name Failed`n$msg`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Check Package Name`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "***Failed***`n$msg`n"
             exit 1
           }
       
@@ -181,7 +184,8 @@ jobs:
           if ($packageName.ToLower() -ne $expectedPackageName.ToLower()) {
             $msg = "Package name mismatch: Expected '$expectedPackageName' but found '$packageName'. Ensure the package name follows the repository naming convention."
             Write-Error $msg
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Check Package Name Failed`n$msg`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Check Package Name`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "***Failed***`n$msg`n"
             exit 1
           }
       
@@ -211,15 +215,15 @@ jobs:
       
       # ---------------------------
       # Publish to GitHub Packages NuGet feed
-      - name: Setup and Publish to GitHub feed
+      - name: Publish to GitHub Package Registry
         if: success() && inputs.newVersion == 'true'
         continue-on-error: true
         run: |
           if (-not (Test-Path -Path ".\output\*.nupkg")) {
             $msg = "No NuGet package found in the output directory. Check if the build process created the package correctly."
             Write-Error $msg
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### GitHub Package Feed`n"
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "ERROR: $msg`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Publish to GitHub Package Registry`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "***ERROR***`n$msg`n"
             exit 1
           }          
           if (-not (nuget sources list | Select-String -Pattern "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json")) {
@@ -236,8 +240,8 @@ jobs:
           catch {
             $msg = "Failed to publish to GitHub feed: $($_.Exception.Message)"
             Write-Error $msg
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### GitHub Package Feed`n"
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "ERROR: $msg`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Publish to GitHub Package Registry`n"
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "***ERROR***`n$msg`n"
             exit 1
           }
 
@@ -260,8 +264,8 @@ jobs:
             if (-not (Test-Path -Path ".\output\*.nupkg")) {
               $msg = "No NuGet package found in the output directory. Check if the build process created the package correctly."
               Write-Error $msg
-              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Nuget.org`n"
-              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "ERROR: $msg`n"
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Publish to Nuget.org`n"
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "***ERROR***`n$msg`n"
               exit 0
             }
             
@@ -278,8 +282,8 @@ jobs:
             catch {
               $msg = "Failed to publish to NuGet.org: $($_.Exception.Message)"
               Write-Error $msg
-              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "### Nuget.org`n"
-              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "ERROR: $msg`n"
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Publish to Nuget.org`n"
+              Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "***ERROR***`n$msg`n"
               exit 1
             }
           }


### PR DESCRIPTION
This pull request makes several improvements to the `.github/workflows/essentialsplugins-4Series-builds.yml` workflow, focusing on enhanced build reporting, error handling, and publishing logic. The changes improve the clarity of build status, automate cleanup after failures, and add more robust steps for publishing packages to GitHub and NuGet.org. Additionally, steps are now grouped and commented for better readability.

**Build and reporting enhancements:**

* The build step now captures and summarizes build output, indicating success or failure directly in the GitHub step summary, and uploads a build log artifact for easier troubleshooting.
* If the build fails, a cleanup step attempts to delete the associated tag from the remote repository and updates the summary with failure details.

**Error handling improvements:**

* Package name checks and publishing steps now write detailed error messages to the GitHub summary, making it easier to identify and diagnose issues when no package is found or when there is a name mismatch. [[1]](diffhunk://#diff-8ff5e521ecdef5ced3d69da42acc94a784c35d791ee82e62725b718b1b494132L81-R176) [[2]](diffhunk://#diff-8ff5e521ecdef5ced3d69da42acc94a784c35d791ee82e62725b718b1b494132L91-R289)

**Publishing logic and automation:**

* The workflow now conditionally creates releases and publishes packages to GitHub Package Registry and NuGet.org only when a new version is being built, with improved error handling and summary updates for each publishing step.
* The NuGet.org publishing step is now wrapped in a try/catch block to handle errors gracefully and provide feedback in the summary, and only runs for public repositories owned by `PepperDash`.

**Workflow structure and readability:**

* Steps are grouped and separated with comments for easier navigation and maintenance of the workflow file. [[1]](diffhunk://#diff-8ff5e521ecdef5ced3d69da42acc94a784c35d791ee82e62725b718b1b494132R79-R151) [[2]](diffhunk://#diff-8ff5e521ecdef5ced3d69da42acc94a784c35d791ee82e62725b718b1b494132L91-R289)

**Workflow dispatch inputs (commented out):**

* Adds (but comments out) a `workflow_dispatch` section with inputs for versioning and build configuration, preparing the workflow for future manual triggers.

Updates:


- Moves publish package (GitHub and Nuget) after upload release
- Adds package check and skip duplicate
- Create solution build output log file, retention 30-days
- Clean up after failed build